### PR TITLE
Implement speedrunner portal tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ The config is located in Plugins/Assassin/config.yml. It has toggles for differe
 
 `freeze-assassin-when-seen` - true/false, changes if the assassin will be frozen in place if the speedrunner puts their crosshair over the assassin. Note if frozen in the air, it may trigger a "Flying is not enabled on the server disconnect", so it is recommended to disable it.
 
+`track-portals` - true/false, if true the compass will track the last known location of a speedrunner before it enters another dimension
+
 
 ## Building
 

--- a/src/main/java/cloud/lagrange/assassin/Config.java
+++ b/src/main/java/cloud/lagrange/assassin/Config.java
@@ -14,6 +14,7 @@ public class Config {
     private boolean compassParticle;
     private boolean compassParticleInNether;
     private boolean compassRandomizeInDifferentWorlds;
+    private boolean trackPortals;
 
     public Config(Plugin plugin) {
         this.plugin = plugin;
@@ -36,6 +37,7 @@ public class Config {
         compassParticleInNether = config.getBoolean("compass-particle-in-nether");
         compassRandomizeInDifferentWorlds = config.getBoolean("compass-random-different-worlds");
         freeze = config.getBoolean("freeze-assassin-when-seen");
+        trackPortals = config.getBoolean("track-portals");
     }
 
     /**
@@ -85,5 +87,12 @@ public class Config {
      */
     public boolean isCompassRandomizeInDifferentWorlds() {
         return compassRandomizeInDifferentWorlds;
+    }
+
+    /**
+     * @return true, if compass should track speedrunners last location after portal entry
+     */
+    public boolean isTrackPortals() {
+        return trackPortals;
     }
 }

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -5,3 +5,4 @@ compass-particle: true
 compass-particle-in-nether: false
 compass-random-different-worlds: true
 freeze-assassin-when-seen: false
+track-portals: false


### PR DESCRIPTION
Implement speedrunner portal tracking

     Create 'track-portals' configuration value.

     Add EventHandler for PlayerPortalEvent to store last speedrunner
     location.

     Extend Worker.updateCompass() to implement player portal location.

     Change == operators to .equals() where relevant.

     Update README.md to reflect config.yml changes

# What does this aim to add?
     Add an option for speedrunner portal tracking
     This is NOT ready to be merged, I need to fully test this and I'll let you know.

# How does it add it?
     Details are in commit message.

# Checkbox
[x] I can use checkboxes
[x] I have included editor files in gitignore
[x] I have followed all style guidelines
