### PR TITLE
Bump dependencies to spigot 1.18.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
 
     <description>A replica of the assassin game mode from Dream's video</description>
     <properties>
-        <java.version>1.8</java.version>
+        <java.version>17</java.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
@@ -71,7 +71,7 @@
         <dependency>
             <groupId>org.spigotmc</groupId>
             <artifactId>spigot-api</artifactId>
-            <version>1.16.1-R0.1-SNAPSHOT</version>
+            <version>1.18.2-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
           </dependency>
     </dependencies>

--- a/src/main/java/cloud/lagrange/assassin/ManHuntPlugin.java
+++ b/src/main/java/cloud/lagrange/assassin/ManHuntPlugin.java
@@ -1,6 +1,6 @@
 package cloud.lagrange.assassin;
 
-import cloud.lagrange.assassin.command.AssasinCommand;
+import cloud.lagrange.assassin.command.AssassinCommand;
 import cloud.lagrange.assassin.command.ManHuntCommand;
 import cloud.lagrange.assassin.command.SpeedrunnerCommand;
 import cloud.lagrange.assassin.event.Events;
@@ -19,7 +19,7 @@ public final class ManHuntPlugin extends JavaPlugin {
         getServer().getPluginManager().registerEvents(new Events(playerData, config), this);
 
         Optional.ofNullable(getCommand("assassin"))
-                .ifPresent(c -> c.setExecutor(new AssasinCommand(this, manager, playerData, config)));
+                .ifPresent(c -> c.setExecutor(new AssassinCommand(this, manager, playerData, config)));
         Optional.ofNullable(getCommand("speedrunner"))
                 .ifPresent(c -> c.setExecutor(new SpeedrunnerCommand(this, manager, playerData)));
         Optional.ofNullable(getCommand("manhunt"))

--- a/src/main/java/cloud/lagrange/assassin/command/AssassinCommand.java
+++ b/src/main/java/cloud/lagrange/assassin/command/AssassinCommand.java
@@ -13,14 +13,14 @@ import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.plugin.Plugin;
 
-public class AssasinCommand implements CommandExecutor {
+public class AssassinCommand implements CommandExecutor {
 
     private final Plugin plugin;
     private final TeamManager teamManager;
     private final PlayerData playerData;
     private final Config config;
 
-    public AssasinCommand(Plugin plugin, TeamManager teamManager, PlayerData playerData, Config config) {
+    public AssassinCommand(Plugin plugin, TeamManager teamManager, PlayerData playerData, Config config) {
         this.plugin = plugin;
         this.teamManager = teamManager;
         this.playerData = playerData;


### PR DESCRIPTION
# What does this aim to add?
- Bump spigot dependency (1.16.1-R0.1-SNAPSHOT => 1.18.2-R0.1-SNAPSHOT)
- Bump default java version (1.8 => 17)
- Fix an internal typo (assasin should be assassin)

# How does it add it?
- All internal changes
- Edited pom.xml and relevant files for typo

# Checkbox
[x] I can use checkboxes
[x] I have included editor files in .gitignore
[x] I have followed all style guidelines
