### PR TITLE
Bump dependencies to 1.19

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -5,6 +5,6 @@
 (Description here)
 
 # Checkbox
-[x] I can use checkboxes
-[ ] I have included editor files in gitignore
-[ ] I have followed all style guidelines
+- [x] I can use checkboxes
+- [ ] I have included editor files in .gitignore
+- [ ] I have followed all style guidelines

--- a/pom.xml
+++ b/pom.xml
@@ -17,15 +17,13 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
-
-
     <build>
         <defaultGoal>clean package</defaultGoal>
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.7.0</version>
+                <version>3.10.1</version>
                 <configuration>
                     <source>${java.version}</source>
                     <target>${java.version}</target>
@@ -34,7 +32,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>3.1.0</version>
+                <version>3.3.0</version>
                 <executions>
                     <execution>
                         <phase>package</phase>
@@ -61,18 +59,19 @@
             <id>spigotmc-repo</id>
             <url>https://hub.spigotmc.org/nexus/content/repositories/snapshots/</url>
         </repository>
-        <repository>
-            <id>sonatype</id>
-            <url>https://oss.sonatype.org/content/groups/public/</url>
-        </repository>
     </repositories>
 
     <dependencies>
         <dependency>
             <groupId>org.spigotmc</groupId>
             <artifactId>spigot-api</artifactId>
-            <version>1.18.2-R0.1-SNAPSHOT</version>
+            <version>1.19-R0.1-SNAPSHOT</version>
             <scope>provided</scope>
           </dependency>
+          <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <version>3.12.0</version>
+        </dependency>
     </dependencies>
 </project>

--- a/src/main/java/cloud/lagrange/assassin/Worker.java
+++ b/src/main/java/cloud/lagrange/assassin/Worker.java
@@ -2,7 +2,7 @@ package cloud.lagrange.assassin;
 
 import cloud.lagrange.assassin.event.Events;
 import cloud.lagrange.assassin.model.ManHuntRole;
-import org.apache.commons.lang.Validate;
+import org.apache.commons.lang3.Validate;
 import org.bukkit.*;
 import org.bukkit.World.Environment;
 import org.bukkit.block.Block;


### PR DESCRIPTION
Bump dependencies to 1.19

     - Updated spigot to 1.19-R0.1-SNAPSHOT.
     - Added commons-lang3 as a dependency as is no longer in spigot.
     - Updated maven plugins to latest version.

# What does this aim to add?
Update plugin dependencies.

# How does it add it?
Updated in pom.xml.

# Checkbox
- [x] I can use checkboxes
- [x] I have included editor files in .gitignore
- [x] I have followed all style guidelines
